### PR TITLE
[SEMINAR] 3차 세미나 코드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/org/sopt/config/JpaAuditingConfig.java
+++ b/src/main/java/org/sopt/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.sopt.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,5 +1,6 @@
 package org.sopt.controller;
 
+import jakarta.validation.Valid;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.ApiResponse;
@@ -22,10 +23,10 @@ public class PostController {
         this.postService = postService;
     }
 
-    // POST /posts ✅ 같이 구현
+    // POST /posts
     @PostMapping
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
-            @RequestBody CreatePostRequest request
+           @Valid @RequestBody CreatePostRequest request
     ) {
         CreatePostResponse response = postService.createPost(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "게시글 등록 성공"));
@@ -52,7 +53,7 @@ public class PostController {
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> updatePost(
             @PathVariable Long id,
-            @RequestBody UpdatePostRequest request
+            @Valid @RequestBody UpdatePostRequest request
     ) {
         postService.updatePost(id, request.title(), request.content());
         return ResponseEntity.ok(ApiResponse.success(null, "게시글 수정 성공"));

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -3,7 +3,7 @@ package org.sopt.controller;
 import jakarta.validation.Valid;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
-import org.sopt.dto.response.ApiResponse;
+import org.sopt.dto.response.BaseResponse;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.service.PostService;
@@ -25,46 +25,46 @@ public class PostController {
 
     // POST /posts
     @PostMapping
-    public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
+    public ResponseEntity<BaseResponse<CreatePostResponse>> createPost(
            @Valid @RequestBody CreatePostRequest request
     ) {
         CreatePostResponse response = postService.createPost(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "게시글 등록 성공"));
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success(response, "게시글 등록 성공"));
     }
 
     // GET /posts 📝 과제
     @GetMapping
-    public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
+    public ResponseEntity<BaseResponse<List<PostResponse>>> getAllPosts() {
         List<PostResponse> responses = postService.getAllPosts();
-        return ResponseEntity.ok(ApiResponse.success(responses, "게시글 목록 조회 성공"));
+        return ResponseEntity.ok(BaseResponse.success(responses, "게시글 목록 조회 성공"));
 
     }
 
     // GET /posts/{id} 📝 과제
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<PostResponse>> getPost(
+    public ResponseEntity<BaseResponse<PostResponse>> getPost(
             @PathVariable Long id
     ) {
         PostResponse response = postService.getPost(id);
-        return ResponseEntity.ok(ApiResponse.success(response, "게시글 조회 성공"));
+        return ResponseEntity.ok(BaseResponse.success(response, "게시글 조회 성공"));
     }
 
     // PUT /posts/{id} 📝 과제
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> updatePost(
+    public ResponseEntity<BaseResponse<Void>> updatePost(
             @PathVariable Long id,
             @Valid @RequestBody UpdatePostRequest request
     ) {
         postService.updatePost(id, request.title(), request.content());
-        return ResponseEntity.ok(ApiResponse.success(null, "게시글 수정 성공"));
+        return ResponseEntity.ok(BaseResponse.success(null, "게시글 수정 성공"));
     }
 
     // DELETE /posts/{id} 📝 과제
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deletePost(
+    public ResponseEntity<BaseResponse<Void>> deletePost(
             @PathVariable Long id
     ) {
         postService.deletePost(id);
-        return ResponseEntity.ok(ApiResponse.success(null, "게시글 삭제 성공"));
+        return ResponseEntity.ok(BaseResponse.success(null, "게시글 삭제 성공"));
     }
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -1,32 +1,59 @@
 package org.sopt.domain;
 
-public class Post {
+import jakarta.persistence.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+import org.sopt.domain.common.BaseTimeEntity;
+
+import java.time.LocalDateTime;
+
+@SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+@Entity
+public class Post extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;          // 게시글 상세 화면 — 특정 게시글 식별용
     private String title;     // 목록, 상세, 글쓰기 화면 — 제목
     private String content;   // 목록(미리보기), 상세(전체) 화면 — 내용
-    private String author;    // 목록, 상세 화면 — 글쓴이
-    private String createdAt; // 목록, 상세 화면 — 작성 시각
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
-    public Post(Long id, String title, String content, String author, String createdAt) {
-        this.id = id;
+    protected Post() {
+    } //JPA 기본 생성자
+
+    public Post(String title, String content, User user) {
         this.title = title;
         this.content = content;
-        this.author = author;
-        this.createdAt = createdAt;
+        this.user = user;
     }
 
-    public Long getId() { return id; }
-    public String getTitle() { return title; }
-    public String getContent() { return content; }
-    public String getAuthor() { return author; }
-    public String getCreatedAt() { return createdAt; }
+    public Long getId() {
+        return id;
+    }
 
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    //snake case
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
     }
 
-    public String getInfo() {
-        return "[" + id + "] " + title + " - " + author + " (" + createdAt + ")\n" + content;
+    public void delete(){
+        this.deletedAt=LocalDateTime.now();
     }
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -2,13 +2,13 @@ package org.sopt.domain;
 
 import jakarta.persistence.*;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 import org.sopt.domain.common.BaseTimeEntity;
 
 import java.time.LocalDateTime;
 
 @SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE id = ?")
-@Where(clause = "deleted_at IS NULL")
+@SQLRestriction("deleted_at IS NULL")
 @Entity
 public class Post extends BaseTimeEntity {
     @Id
@@ -47,7 +47,6 @@ public class Post extends BaseTimeEntity {
         return user;
     }
 
-    //snake case
     public void update(String title, String content) {
         this.title = title;
         this.content = content;

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -1,0 +1,32 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String nickname;
+    private String emaill;
+
+    protected User(){}
+
+    public User(String nickname, String emaill) {
+        this.nickname = nickname;
+        this.emaill = emaill;
+    }
+
+    public String getEmaill() {
+        return emaill;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -9,17 +9,17 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String nickname;
-    private String emaill;
+    private String email;
 
     protected User(){}
 
-    public User(String nickname, String emaill) {
+    public User(String nickname, String email) {
         this.nickname = nickname;
-        this.emaill = emaill;
+        this.email = email;
     }
 
-    public String getEmaill() {
-        return emaill;
+    public String getEmail() {
+        return email;
     }
 
     public String getNickname() {

--- a/src/main/java/org/sopt/domain/common/BaseTimeEntity.java
+++ b/src/main/java/org/sopt/domain/common/BaseTimeEntity.java
@@ -1,5 +1,6 @@
 package org.sopt.domain.common;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/org/sopt/domain/common/BaseTimeEntity.java
+++ b/src/main/java/org/sopt/domain/common/BaseTimeEntity.java
@@ -1,0 +1,29 @@
+package org.sopt.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    // getter
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -1,4 +1,12 @@
 package org.sopt.dto.request;
 
-public record CreatePostRequest(String title, String content, String author) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreatePostRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 50, message = "제목은 최대 50자 이내여야 합니다")
+        String title,
+        String content,
+        Long userId) {
 }

--- a/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
@@ -1,6 +1,13 @@
 package org.sopt.dto.request;
 
-public record UpdatePostRequest(String title, String content) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdatePostRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 50, message = "제목은 최대 50자 이내여야 합니다")
+        String title,
+        String content) {
 }
 
 

--- a/src/main/java/org/sopt/dto/response/BaseResponse.java
+++ b/src/main/java/org/sopt/dto/response/BaseResponse.java
@@ -3,7 +3,7 @@ package org.sopt.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ApiResponse<T> {
+public class BaseResponse<T> {
     private boolean success;
     private String code;
     private String message;
@@ -15,16 +15,16 @@ public class ApiResponse<T> {
 
     public T getData() { return data; }
 
-    public static <T> ApiResponse<T> success(T data, String message) {
-        ApiResponse<T> response = new ApiResponse<>();
+    public static <T> BaseResponse<T> success(T data, String message) {
+        BaseResponse<T> response = new BaseResponse<>();
         response.success = true;
         response.message=message;
         response.data = data;
         return response;
     }
 
-    public static <T> ApiResponse<T> error(String code, String message){
-        ApiResponse<T> response = new ApiResponse<>();
+    public static <T> BaseResponse<T> error(String code, String message){
+        BaseResponse<T> response = new BaseResponse<>();
         response.success = false;
         response.message = message;
         response.code = code;

--- a/src/main/java/org/sopt/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostResponse.java
@@ -6,7 +6,7 @@ public record PostResponse(
         Long id,
         String title,
         String content,
-        String author,
+        Long userId,
         String createdAt
 ) {
     public static PostResponse from(Post post) {
@@ -14,8 +14,8 @@ public record PostResponse(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
-                post.getAuthor(),
-                post.getCreatedAt()
+                post.getUser().getId(),
+                post.getCreatedAt().toString()
         );
     }
 }

--- a/src/main/java/org/sopt/exception/BusinessException.java
+++ b/src/main/java/org/sopt/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package org.sopt.exception;
+
+
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.errorCode=errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/org/sopt/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/exception/ErrorCode.java
@@ -10,7 +10,14 @@ public enum ErrorCode {
 
     // 공통 에러 (COMMON_xxx)
     INVALID_INPUT("COMMON_001", "잘못된 입력입니다.", HttpStatus.BAD_REQUEST),
-    INTERNAL_SERVER_ERROR("COMMON_002", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    INTERNAL_SERVER_ERROR("COMMON_002", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_REQUEST_BODY("COMMON_003", "요청 본문을 읽을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TYPE_VALUE("COMMON_004", "잘못된 타입의 값입니다.", HttpStatus.BAD_REQUEST),
+
+
+
+    // 유저 관련 에러
+    USER_NOT_FOUND("USER_001", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package org.sopt.exception;
 
-import org.sopt.dto.response.ApiResponse;
+import org.sopt.dto.response.BaseResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -14,11 +14,11 @@ public class GlobalExceptionHandler {
 
     // BusinessException
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ApiResponse<Void>> handleBusinessException (
+    public ResponseEntity<BaseResponse<Void>> handleBusinessException (
             BusinessException e
     ) {
         ErrorCode errorCode = e.getErrorCode();
-        ApiResponse<Void> errorResponse = ApiResponse.error(
+        BaseResponse<Void> errorResponse = BaseResponse.error(
                 errorCode.getCode(),
                 e.getMessage()
         );
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
 
     // @Valid 검증 실패 (400)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
+    public ResponseEntity<BaseResponse<Void>> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException e
     ) {
         String errorMessage = e.getBindingResult()
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
                 .orElse("잘못된 입력입니다.");
 
         ErrorCode errorCode = ErrorCode.INVALID_INPUT;
-        ApiResponse<Void> errorResponse = ApiResponse.error(
+        BaseResponse<Void> errorResponse = BaseResponse.error(
                 errorCode.getCode(),
                 errorMessage
         );
@@ -51,11 +51,11 @@ public class GlobalExceptionHandler {
 
     // JSON 파싱 오류 (400)
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(
+    public ResponseEntity<BaseResponse<Void>> handleHttpMessageNotReadableException(
             HttpMessageNotReadableException e
     ) {
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST_BODY;
-        ApiResponse<Void> errorResponse = ApiResponse.error(
+        BaseResponse<Void> errorResponse = BaseResponse.error(
                 errorCode.getCode(),
                 errorCode.getMessage()
         );
@@ -66,11 +66,11 @@ public class GlobalExceptionHandler {
 
     // 타입 불일치 (400)
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
+    public ResponseEntity<BaseResponse<Void>> handleMethodArgumentTypeMismatchException(
             MethodArgumentTypeMismatchException e
     ) {
         ErrorCode errorCode = ErrorCode.INVALID_TYPE_VALUE;
-        ApiResponse<Void> errorResponse = ApiResponse.error(
+        BaseResponse<Void> errorResponse = BaseResponse.error(
                 errorCode.getCode(),
                 errorCode.getMessage()
         );
@@ -81,11 +81,11 @@ public class GlobalExceptionHandler {
 
     // 그 외 예외 처리 (500)
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(
+    public ResponseEntity<BaseResponse<Void>> handleException(
             Exception e
     ) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-        ApiResponse<Void> errorResponse = ApiResponse.error(
+        BaseResponse<Void> errorResponse = BaseResponse.error(
                 errorCode.getCode(),
                 errorCode.getMessage()
         );

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package org.sopt.exception;
 import org.sopt.dto.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -19,6 +21,28 @@ public class GlobalExceptionHandler {
         ApiResponse<Void> errorResponse = ApiResponse.error(
                 errorCode.getCode(),
                 e.getMessage()
+        );
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
+    }
+
+    // @Valid 검증 실패 (400)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e
+    ) {
+        String errorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("잘못된 입력입니다.");
+
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT;
+        ApiResponse<Void> errorResponse = ApiResponse.error(
+                errorCode.getCode(),
+                errorMessage
         );
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -2,16 +2,18 @@ package org.sopt.exception;
 
 import org.sopt.dto.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // PostNotFoundException
-    @ExceptionHandler(PostNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handlePostNotFoundException (
-            PostNotFoundException e
+    // BusinessException
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException (
+            BusinessException e
     ) {
         ErrorCode errorCode = e.getErrorCode();
         ApiResponse<Void> errorResponse = ApiResponse.error(
@@ -23,26 +25,41 @@ public class GlobalExceptionHandler {
                 .body(errorResponse);
     }
 
-    // IllegalArgumentException (유효성 검증 실패)
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(
-            IllegalArgumentException e
+    // JSON 파싱 오류 (400)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e
     ) {
-        ErrorCode errorCode = ErrorCode.INVALID_INPUT;
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST_BODY;
         ApiResponse<Void> errorResponse = ApiResponse.error(
-            errorCode.getCode(),
-            e.getMessage()
+                errorCode.getCode(),
+                errorCode.getMessage()
         );
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(errorResponse);
     }
 
-    // 그외 모든 예외 처리
+    // 타입 불일치 (400)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e
+    ) {
+        ErrorCode errorCode = ErrorCode.INVALID_TYPE_VALUE;
+        ApiResponse<Void> errorResponse = ApiResponse.error(
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
+    }
+
+    // 그 외 예외 처리 (500)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(
             Exception e
-    ){
+    ) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         ApiResponse<Void> errorResponse = ApiResponse.error(
                 errorCode.getCode(),

--- a/src/main/java/org/sopt/exception/PostNotFoundException.java
+++ b/src/main/java/org/sopt/exception/PostNotFoundException.java
@@ -1,14 +1,7 @@
 package org.sopt.exception;
 
-public class PostNotFoundException extends RuntimeException{
-    private final ErrorCode errorCode;
-
+public class PostNotFoundException extends BusinessException{
     public PostNotFoundException() {
-        super(ErrorCode.POST_NOT_FOUND.getMessage());
-        this.errorCode=ErrorCode.POST_NOT_FOUND;
-    }
-
-    public ErrorCode getErrorCode(){
-        return errorCode;
+        super(ErrorCode.POST_NOT_FOUND);
     }
 }

--- a/src/main/java/org/sopt/exception/UserNotFoundException.java
+++ b/src/main/java/org/sopt/exception/UserNotFoundException.java
@@ -2,7 +2,7 @@ package org.sopt.exception;
 
 public class UserNotFoundException extends BusinessException {
 
-    public UserNotFoundException(ErrorCode errorCode) {
-        super(errorCode);
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
     }
 }

--- a/src/main/java/org/sopt/exception/UserNotFoundException.java
+++ b/src/main/java/org/sopt/exception/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package org.sopt.exception;
+
+public class UserNotFoundException extends BusinessException {
+
+    public UserNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -1,41 +1,9 @@
 package org.sopt.repository;
 
 import org.sopt.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
 @Repository
-public class PostRepository {
-    private final List<Post> postList = new ArrayList<>();
-    private Long nextId = 1L;
-
-    public Post save(Post post) {
-        postList.add(post);
-        return post;
-    }
-
-    public List<Post> findAll() {
-        return new ArrayList<>(postList);
-    }
-
-    public Optional<Post> findById(Long id) {
-        return postList.stream()
-                .filter(p -> p.getId().equals(id))
-                .findFirst();
-    }
-
-    public boolean deleteById(Long id) {
-        return postList.removeIf(p -> p.getId().equals(id));
-    }
-
-    public void delete(Post post){
-        postList.remove(post);
-    }
-
-    public Long generateId() {
-        return nextId++;
-    }
+public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/src/main/java/org/sopt/repository/UserRepository.java
+++ b/src/main/java/org/sopt/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.repository;
+
+import org.sopt.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);  // 메서드 이름으로 쿼리 자동 생성
+}

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -67,6 +67,6 @@ public class PostService {
     public void deletePost(Long id) {
        Post post = postRepository.findById(id)
                .orElseThrow(PostNotFoundException::new);
-       post.delete();
+       postRepository.delete(post);
     }
 }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -1,37 +1,44 @@
 package org.sopt.service;
+import org.springframework.transaction.annotation.Transactional;
 import org.sopt.domain.Post;
+import org.sopt.domain.User;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.exception.PostNotFoundException;
+import org.sopt.exception.UserNotFoundException;
 import org.sopt.repository.PostRepository;
-import org.sopt.validator.PostValidator;
+import org.sopt.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
 public class PostService {
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
-    public PostService(PostRepository postRepository){
+    public PostService(PostRepository postRepository, UserRepository userRepository){
         this.postRepository=postRepository;
+        this.userRepository=userRepository;
     }
 
     // CREATE
+    @Transactional
     public CreatePostResponse createPost(CreatePostRequest request) {
-        PostValidator.validateTitle(request.title());
-        String createdAt = java.time.LocalDateTime.now().toString();
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(UserNotFoundException::new);
+
         Post post = new Post(
-                postRepository.generateId(),
+
                 request.title(),
                 request.content(),
-                request.author(),
-                createdAt);
+                user);
         postRepository.save(post);
         return new CreatePostResponse(post.getId());
     }
 
     // READ - 전체 📝 과제
+    @Transactional(readOnly=true)
     public List<PostResponse> getAllPosts() {
       return postRepository.findAll().stream()
               .map(PostResponse::from)
@@ -39,25 +46,27 @@ public class PostService {
     }
 
     // READ - 단건 📝 과제
+    @Transactional(readOnly=true)
     public PostResponse getPost(Long id) {
         Post post = postRepository.findById(id)
-                .orElseThrow(()-> new PostNotFoundException());
+                .orElseThrow(PostNotFoundException::new);
         return PostResponse.from(post);
     }
 
     // UPDATE 📝 과제
+    @Transactional
     public void updatePost(Long id, String newTitle, String newContent) {
         Post post = postRepository.findById(id)
-                .orElseThrow(()-> new PostNotFoundException());
+                .orElseThrow(PostNotFoundException::new);
 
-        PostValidator.validateTitle(newTitle);
         post.update(newTitle, newContent);
     }
 
     // DELETE 📝 과제
+    @Transactional
     public void deletePost(Long id) {
        Post post = postRepository.findById(id)
-               .orElseThrow(()-> new PostNotFoundException());
-       postRepository.delete(post);
+               .orElseThrow(PostNotFoundException::new);
+       post.delete();
     }
 }

--- a/src/main/java/org/sopt/validator/PostValidator.java
+++ b/src/main/java/org/sopt/validator/PostValidator.java
@@ -1,13 +1,16 @@
 package org.sopt.validator;
 
+import org.sopt.exception.BusinessException;
+import org.sopt.exception.ErrorCode;
+
 public class PostValidator {
 
     public static void validateTitle(String title) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("제목은 필수입니다.");
+            throw new BusinessException(ErrorCode.POST_TITLE_REQUIRED);
         }
         if (title.length() > 50) {
-            throw new IllegalArgumentException("제목은 50자 이내여야 합니다.");
+            throw new BusinessException(ErrorCode.POST_TITLE_TOO_LONG);
         }
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] Post 엔티티 전환
- [x] PostRepository 전환
- [x] User 엔티티 만들기
- [x] UserRepository 구현
- [x] PostService 전환  

<br>

### **구현한 내용에 대해서 설명해주세요**
 1. BusinessException으로 예외처리 개선
    - 모든 커스텀 예외의 부모 클래스로 BusinessException을 구현했습니다. 
    - PostNotFoundException, UserNotFoundException이 BusinessException을 상속하도록 리팩토링해 코드 중복을 제거했습니다.
 
2. BaseTimeEntity, Soft Delete 추가 
   - @CreatedDate, @LastModifiedDate 어노테이션과 JPA Auditing을 활용해 생성일시와 수정일시가 자동으로 관리되도록 했습니다.
   - deletedAt 필드를 추가하고, 삭제 시 실제 DELETE 대신 deletedAt에 삭제 시점을 기록하도록 구현했습니다.

3. @Valid 적용
   - Controller 메서드의 @RequestBody 파라미터에 @Valid 어노테이션을 추가해 요청 데이터가 자동으로 검증되도록 했습니다.

4. Post 엔티티 전환 및 User 연결
   - Post를 @Entity로 변경하고 @Id, @GeneratedValue(strategy = GenerationType.IDENTITY)를 추가해 JPA 엔티티로 전환했습니다.
   - 기존 수동 Repository 구현을 제거하고 PostRepository를 JpaRepository<Post, Long>를 상속하도록 변경했습니다.
   - User 엔티티를 새로 생성하고 @Entity, @Table(name = "users") 어노테이션을 추가했습니다. 

<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**
- JPA Auditing 도입
  - @MappedSuperclass를 사용하면 상속을 통해 공통 필드를 관리할 수 있다는 것을 알게 되었습니다.
  - @CreatedDate, @LastModifiedDate 어노테이션과 JPA Auditing을 활용하면 시간 필드가 자동으로 관리된다는 것을 배웠습니다.
  
- MethodArgumentNotValidException 처리
  - @Valid 검증 실패 시 MethodArgumentNotValidException이 발생한다는 것을 배웠습니다.
  - GlobalExceptionHandler에 이 예외를 처리하는 핸들러를 추가하고, e.getBindingResult().getFieldErrors()에서 첫 번째 에러 메시지를 추출해 일관된 형식으로 응답하도록 구현했습니다.



<br>

---

## 🚨 참고 사항
